### PR TITLE
CustomChar for i2c, Backlight support and Bugfix

### DIFF
--- a/lcd_hd44780.lua
+++ b/lcd_hd44780.lua
@@ -145,10 +145,10 @@ function lcd_hd44780:clear()
             end
         end 
     else
-		drv:command(0x01, lcd_hd44780.detect_e(self))
-		self.x = 0
-		self.y = 0
-	end
+        drv:command(0x01, lcd_hd44780.detect_e(self))
+        self.x = 0
+        self.y = 0
+    end
 end 
 
 function lcd_hd44780:detect_e()
@@ -164,16 +164,16 @@ function lcd_hd44780:has_two_e()
 end
 
 function lcd_hd44780:setCustomChar(position, pattern)
-	drv:command(bit.bor(0x40, bit.lshift(position, 3)), lcd_hd44780.detect_e(self))
+    drv:command(bit.bor(0x40, bit.lshift(position, 3)), lcd_hd44780.detect_e(self))
 
-	gpio.write(drv.pins['RS'], gpio.HIGH)
+    drv:setrs(true)
 
-	for key,value in pairs(pattern) do
-		drv:_write8(pattern[key], lcd_hd44780.detect_e(self))
-	end
-	
-	drv:command(0x00, lcd_hd44780.detect_e(self), true)
-	lcd_hd44780.clear(self)
+    for key,value in pairs(pattern) do
+        drv:_write8(pattern[key], lcd_hd44780.detect_e(self))
+    end
+
+    drv:command(0x00, lcd_hd44780.detect_e(self), true)
+    lcd_hd44780.clear(self)
 end
 
 return lcd_hd44780

--- a/lcd_hd44780_gpio.lua
+++ b/lcd_hd44780_gpio.lua
@@ -69,4 +69,8 @@ function drv:write(ch, enable)
     drv._write8(self, ch:byte(1), enable)        
 end
 
+function drv:setrs(high)
+    if (high) then gpio.write(self.pins['RS'], gpio.HIGH) else gpio.write(self.pins['RS'], gpio.LOW) end
+end
+
 return drv

--- a/lcd_hd44780_i2c.lua
+++ b/lcd_hd44780_i2c.lua
@@ -16,6 +16,7 @@ function drv.new(addr, sda, scl, pins)
     self.scl = scl
     self._rs = 0
     self._buffer = nil
+    self._blon = true
     if pins == nil then
         self.pins = {
             RS= 4,
@@ -25,6 +26,7 @@ function drv.new(addr, sda, scl, pins)
             DB5= 1,
             DB6= 2,
             DB7= 3,
+            BL= nil
         }
     else
         self.pins = pins
@@ -54,7 +56,6 @@ function drv:_write4(ch, enable)
     if bit.isset(ch, 1) then self._buffer = self._buffer + math.pow(2, self.pins['DB5']) end        
     if bit.isset(ch, 2) then self._buffer = self._buffer + math.pow(2, self.pins['DB6']) end       
     if bit.isset(ch, 3) then self._buffer = self._buffer + math.pow(2, self.pins['DB7']) end
-    self._buffer = ch
     drv._send(self, enable)
 end
 
@@ -63,19 +64,39 @@ function drv:_write8(ch, enable)
     drv._write4(self, bit.band(ch, 0x0F), enable)
 end
 
+function drv:_getblpin()
+    if (self.pins['BL'] == nil or self._blon == false) then
+        return 0
+    else
+        return math.pow(2, self.pins['BL'])
+    end
+end
+
 function drv:_send(enable)  
     enable = "E"..enable
     i2c.start(self.port)
-    i2c.address(self.port, self.addr, i2c.TRANSMITTER)    
-    i2c.write(self.port, self._buffer +  math.pow(2, self.pins[enable]) + self._rs)
+    i2c.address(self.port, self.addr, i2c.TRANSMITTER)
+    i2c.write(self.port, self._buffer +  math.pow(2, self.pins[enable]) + self._rs + drv._getblpin(self))
     tmr.delay(5)
-    i2c.write(self.port, self._buffer)
+    i2c.write(self.port, self._buffer + drv._getblpin(self))
     i2c.stop(self.port)
 end
 
 function drv:write(ch, enable)
     self._rs =  math.pow(2, self.pins['RS'])
     self._write8(self, ch:byte(1), enable)        
+end
+
+function drv:backlight(on)
+    self._blon = on
+    i2c.start(self.port)
+    i2c.address(self.port, self.addr, i2c.TRANSMITTER)
+    i2c.write(self.port, drv._getblpin(self))
+    i2c.stop(self.port)
+end
+
+function drv:setrs(high)
+    if (high) then self._rs = math.pow(2, self.pins['RS']) else self._rs = 0 end
 end
 
 return drv

--- a/sample/lcd_hd44780.md
+++ b/sample/lcd_hd44780.md
@@ -40,6 +40,19 @@ If using i2c, set correct address, i2c pins and pin if different from default:
 
     drv = i2c_driver(0x20, 4, 5, pins)
 
+A lot of already prebuilt PCF8574AT modules for i2c uses this configuration:
+
+    drv = gpio_driver(0x3F, 5, 6, {
+        RS= 0,
+        E1= 2,
+        E2= nil,
+        DB4= 4,
+        DB5= 5,
+        DB6= 6,
+        DB7= 7,
+        BL= 3
+    })
+
 ## Default wiring (GPIO):
 
         pins = {
@@ -179,6 +192,15 @@ If using i2c, set correct address, i2c pins and pin if different from default:
         pattern = {0x0,0x0,0xa,0x0,0x11,0xe,0x0}
         lcd:setCustomChar(0, pattern)
         lcd:write("be happy \000")
+
+- backlight
+
+    Works currently only with i2c. Set the optional `BL` pin in the pin configuration. When you are using a prebuilt PCF8574 module, you need to set this, otherwise the display will turn off, everytime you use `write`. Use this command to turn backlight on and off:
+    
+        -- turn on:
+        drv:backlight(true)
+        -- turn off:
+        drv:backlight(false)
 
 ## Using as a remote LCD (with CharLCD)
 


### PR DESCRIPTION
* Fixed lcd_hd44780_i2c (`drv:_write4` was not sending correct bits)
* Added Backlight support for i2c, which is needed for already prebuilt i2c modules (there is now an additional new pin in the pin configuration called `BL`)
* `setCustomChar` now also works with i2c (had to move the control of RS-pin to the driver)
* Updated documentation